### PR TITLE
Added CS acronym to the end of Computer Science

### DIFF
--- a/topic/berkeley_bjc/intro/broadcast-animations-music.topic
+++ b/topic/berkeley_bjc/intro/broadcast-animations-music.topic
@@ -2,7 +2,7 @@ title: Broadcast, Animations, and Music
 
 {
 h2: Big Ideas
-big-idea: Explore Abstraction as it relates to Computer Science
+big-idea: Explore Abstraction as it relates to Computer Science (CS)
 big-idea: Understand and analyze some of the impact of the internet on our culture
 
 	video: Video Lecture: Abstraction [https://coursesharing.org/courses/6/lectures/7]


### PR DESCRIPTION
I wanted to test gifhub, so I changed a single line.
