### PR TITLE
Remove old rotate-board tests

### DIFF
--- a/cur/programming/2048-testing/basic_hw3_tests.html
+++ b/cur/programming/2048-testing/basic_hw3_tests.html
@@ -24,16 +24,7 @@
 
 <p><img src="/bjc-r/img/2048-testing/set_item_of_test.png" alt="lists of nouns, verbs, etc." title="lists of nouns, verbs, etc." /></p>
 
-<p>This test is a little trickier. Since we're testing a command block, we have to create a temporary variable to use that command block. In this case, the test verifies that if you set position (1, 4) to 2, that the actual value stored at that position is a 2. It also verifies that the value at position (1, 2) is just zero (since it hasn't been set). Again, if you run this test, you should get back <code>true</code> twice. Make sure that this test makes sense before proceeding.
-
-<div class="alert quoteGreen alert-success">
-  <h4><strong>For You To Do:</strong></h4>
-  <p><b>First:</b> let's start writing our own test for <img src="/bjc-r/img/2048-testing/rotated_row.png">. This block is trickier to understand, so make sure to click the link in the 2048 spec under the "Description" column. Note that two of the three expected output values are blank. Your goal is to figure out what numbers go here so that the output is True. Try to fill in these numbers. DO NOT USE TRIAL AND ERROR! You will need to read the description of this block very carefully to understand what numbers you need to fill in. We recommend you actually rotate a physical piece of paper to work out the answers.</p>
-
-  <p>When you've identified the correct outputs for the <img src="/bjc-r/img/2048-testing/rotated_row.png"> block, the test should say true three times.</p>
-
-  <p><b>Second:</b> to ensure we feel comfortable writing tests entirely on our own, write a test for  <img src="/bjc-r/img/2048-testing/score_tile.png">. Make sure to test at least 3 different values.</p>
-</div>
+<p>This test is a little trickier. Since we're testing a command block, we have to create a temporary variable to use that command block. In this case, the test verifies that if you set position (1, 4) to 2, that the actual value stored at that position is a 2. It also verifies that the value at position (1, 2) is just zero (since it hasn't been set). Again, if you run this test, you should get back <code>true</code> twice. Make sure that this test makes sense before proceeding.</p>
 
    </body>
 </html>


### PR DESCRIPTION
Alex added the new "merge up" TODO on the final page of the lab. Since there is no more explanation for "rotate-board" or "score of", and the students don't have to work with those, I removed the old tests.
